### PR TITLE
update to v1.1.0 in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ GitHub Action that annotates code with pylint linting results captured using
 
 ## Usage
 
+Recommended usage with [Pylint action](https://github.com/marketplace/actions/pylint-annotation-action)
+
 ### Basic
 
 You need to add permissions for this tool.
@@ -19,7 +21,7 @@ permissions:
 ```
 
 ```yaml
-uses: karpikpl/pylint-annotation-action@1.0.0
+uses: karpikpl/pylint-annotation-action@1.1.0
 with:
   lint-file: pylint.json
   pylint-result-code: 0
@@ -30,7 +32,7 @@ with:
 
 ### `head-sha`
 
-**Required** SHA of the commit to annotate.
+**Optional** SHA of the commit to annotate. Defaults to `github.sha` - current commit.
 
 ### `lint-file`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ GitHub Action that annotates code with pylint linting results captured using
 
 ## Usage
 
-Recommended usage with [Pylint action](https://github.com/marketplace/actions/pylint-annotation-action)
+Recommended usage with
+[Pylint action](https://github.com/marketplace/actions/pylint-annotation-action)
 
 ### Basic
 
@@ -32,7 +33,8 @@ with:
 
 ### `head-sha`
 
-**Optional** SHA of the commit to annotate. Defaults to `github.sha` - current commit.
+**Optional** SHA of the commit to annotate. Defaults to `github.sha` - current
+commit.
 
 ### `lint-file`
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
     default: 0
   head-sha:
     description: 'SHA of the commit to annotate.'
+    default: '${{ github.sha }}'
     required: true
   repo-owner:
     description: 'The repo owner.'


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `action.yml` files to enhance the usage instructions and default values for the Pylint annotation action. The most important changes include updating the recommended usage, changing the action version, and modifying the default value for the `head-sha` input.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R12): Added a recommended usage section with a link to the Pylint action.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R24): Updated the action version from `1.0.0` to `1.1.0`.

Default value modifications:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R35): Changed the `head-sha` input from required to optional and set its default value to `github.sha`.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R17): Set the default value of the `head-sha` input to `${{ github.sha }}`.